### PR TITLE
Add mime type and filename as result for resolveContent

### DIFF
--- a/android/src/main/kotlin/jp/espresso3389/content_resolver/ContentResolverPlugin.kt
+++ b/android/src/main/kotlin/jp/espresso3389/content_resolver/ContentResolverPlugin.kt
@@ -2,6 +2,7 @@ package jp.espresso3389.content_resolver
 
 import android.net.Uri
 import android.os.ParcelFileDescriptor
+import android.provider.OpenableColumns
 import androidx.annotation.NonNull
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -43,7 +44,7 @@ class ContentResolverPlugin: FlutterPlugin, MethodCallHandler {
               val (address_, byteBuffer) = allocBuffer(buffer.size())
               address = address_
               byteBuffer.put(buffer.toByteArray())
-              result.success(hashMapOf("address" to address, "length" to buffer.size(), "mimeType" to getMimeType(uri)))
+              result.success(hashMapOf("address" to address, "length" to buffer.size(), "mimeType" to getMimeType(uri), "fileName" to getFileName(uri)))
             }
           }
           "writeContent" -> {
@@ -75,6 +76,16 @@ class ContentResolverPlugin: FlutterPlugin, MethodCallHandler {
     val cr = flutterPluginBinding.applicationContext.contentResolver
     return cr.getType(uri)
   }
+
+  private fun getFileName(uri: Uri): String? {
+    val cr = flutterPluginBinding.applicationContext.contentResolver
+    return cr.query(uri, null, null, null, null)?.use { cursor ->
+      val nameColumnIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+      cursor.moveToFirst()
+      return cursor.getString(nameColumnIndex)
+    }
+  }
+
   private fun openOutputStream(uri: Uri, mode: String): OutputStream {
     val cr = flutterPluginBinding.applicationContext.contentResolver
     return BufferedOutputStream(ParcelFileDescriptor.AutoCloseOutputStream(cr.openFileDescriptor(uri, mode)))

--- a/lib/content_resolver.dart
+++ b/lib/content_resolver.dart
@@ -75,7 +75,7 @@ class ContentItem {
   /// mimetype of the content
   String? mimeType;
 
-  /// mimetype of the content
+  /// filename of the content
   String? fileName;
 
   ContentItem(this.buffer, this.mimeType, this.fileName);

--- a/lib/content_resolver.dart
+++ b/lib/content_resolver.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart';
 
 /// Resolves `content:xxxx` style URI using [ContentResolver](https://developer.android.com/reference/android/content/ContentResolver).
 class ContentResolver {
-  ContentResolver._(this.address, this.length, this.mimeType);
+  ContentResolver._(this.address, this.length, this.mimeType, this.fileName);
 
   /// Buffer address.
   final int address;
@@ -13,14 +13,19 @@ class ContentResolver {
   /// Buffer length.
   final int length;
 
-  final String mimeType;
+  // Mime type
+  final String? mimeType;
+
+  // File name
+  final String? fileName;
 
   static const MethodChannel _channel = const MethodChannel('content_resolver');
 
   /// Directly get the content in [Uint8List] buffer.
   static Future<ContentItem> resolveContent(String uri) async {
     final cr = await resolve(uri);
-    final ret = ContentItem(Uint8List.fromList(cr.buffer), cr.mimeType);
+    final ret =
+        ContentItem(Uint8List.fromList(cr.buffer), cr.mimeType, cr.fileName);
 
     cr.dispose();
     return ret;
@@ -32,7 +37,10 @@ class ContentResolver {
     try {
       final result = await _channel.invokeMethod('getContent', uri);
       return ContentResolver._(
-          result['address'] as int, result['length'] as int, result['mimeType'] as String);
+          result['address'] as int,
+          result['length'] as int,
+          result['mimeType'] as String?,
+          result['fileName'] as String?);
     } on Exception {
       throw Exception('Handling URI "$uri" failed.');
     }
@@ -59,12 +67,16 @@ class ContentResolver {
       Pointer<Uint8>.fromAddress(address).asTypedList(length);
 }
 
-// represents content item 
+// represents content item
 class ContentItem {
   /// byte buffer that contains the content
   Uint8List buffer;
-  /// mimetype of the content
-  String mimeType;
 
-  ContentItem(this.buffer, this.mimeType);
+  /// mimetype of the content
+  String? mimeType;
+
+  /// mimetype of the content
+  String? fileName;
+
+  ContentItem(this.buffer, this.mimeType, this.fileName);
 }


### PR DESCRIPTION
I needed this plugin to respond on open file requests from the OS. 
But the original plugin did not provide filename and mimetype. 
