### PR TITLE
Disable build-id link option to allow reproducible builds

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.4.1)
 
+add_link_options("LINKER:--build-id=none")
+
 add_library(dbufhelper SHARED cpp/directBufferAndroid.cpp)
 
 target_compile_options(dbufhelper PRIVATE -DBUILD_FOR_ANDROID)


### PR DESCRIPTION
To enable reproducible builds, we can disable the `build-id` in the linker options, as suggested by @linsu

See:
- https://github.com/BenderBlog/traintime_pda/issues/57
- https://gitlab.com/fdroid/rfp/-/issues/2522#note_2456892680